### PR TITLE
Add API URL to configuration menu

### DIFF
--- a/src/main/java/com/idyl/prophunt/PropHuntConfig.java
+++ b/src/main/java/com/idyl/prophunt/PropHuntConfig.java
@@ -42,6 +42,15 @@ public interface PropHuntConfig extends Config
 	default String models() { return "Bush: 1565, Crate: 12125, Rock Pile: 1391"; }
 
 	@ConfigItem(
+		keyName = "apiServerUrl",
+		name = "API Server URL",
+		description = "The URL of the API to connect to.",
+		position = 3,
+		section = setupSettings
+	)
+	default String apiServerUrl() { return "http://props.idyl.live:8080"; }
+
+	@ConfigItem(
 			keyName = "hideMode",
 			name = "Hide Mode",
 			description = "Toggle whether you are currently hiding or not",

--- a/src/main/java/com/idyl/prophunt/PropHuntDataManager.java
+++ b/src/main/java/com/idyl/prophunt/PropHuntDataManager.java
@@ -12,11 +12,13 @@ import java.util.HashMap;
 @Slf4j
 @Singleton
 public class PropHuntDataManager {
-    private final String baseUrl = "http://props.idyl.live:8080";
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
     @Inject
     private PropHuntPlugin plugin;
+
+    @Inject
+    private PropHuntConfig config;
 
     @Inject
     private OkHttpClient okHttpClient;
@@ -27,7 +29,7 @@ public class PropHuntDataManager {
     protected void updatePropHuntApi(PropHuntPlayerData data)
     {
         String username = urlifyString(data.username);
-        String url = baseUrl.concat("/prop-hunters/"+username);
+        String url = config.apiServerUrl().concat("/prop-hunters/"+username);
 
         try
         {
@@ -71,7 +73,7 @@ public class PropHuntDataManager {
 
         try {
             Request r = new Request.Builder()
-                    .url(baseUrl.concat("/prop-hunters/".concat(playersString)))
+                    .url(config.apiServerUrl().concat("/prop-hunters/".concat(playersString)))
                     .get()
                     .build();
 


### PR DESCRIPTION
Allows users to change the API URL used for networking player props. Enables other servers to be used in the scenario the default server is down, as it has been recently. 

#8 #9 